### PR TITLE
Fix issue with AMR (adaptive mesh refinement)

### DIFF
--- a/Sources/pimpleCentralFoam/pimpleCentralDyMFoam/pimpleCentralDyMFoam.C
+++ b/Sources/pimpleCentralFoam/pimpleCentralDyMFoam/pimpleCentralDyMFoam.C
@@ -172,6 +172,9 @@ int main(int argc, char *argv[])
         if (mesh.moving() && checkMeshCourantNo)
         {
             #include "centralMeshCourantNo.H"
+        }
+        if (mesh.changing())
+        {
             #include "markBadQualityCells.H"
         }
 

--- a/Sources/reactingPimpleCentralDyMFoam/reactingPimpleCentralDyMFoam.C
+++ b/Sources/reactingPimpleCentralDyMFoam/reactingPimpleCentralDyMFoam.C
@@ -178,6 +178,9 @@ int main(int argc, char *argv[])
         if (mesh.moving() && checkMeshCourantNo)
         {
             #include "centralMeshCourantNo.H"
+        }
+        if (mesh.changing())
+        {
             #include "markBadQualityCells.H"
         }
 


### PR DESCRIPTION
In the `pimpleCentralDyMFoam` and `reactingPimpleCentralDyMFoam` solvers, bad-quality cells are recomputed in the following if clause:
```Cpp
if (mesh.moving() && checkMeshCourantNo)
{
    #include "centralMeshCourantNo.H"
    #include "markBadQualityCells.H"
}
```
However, `markBadQualityCells` stores a list of cell IDs, which will become outdated once the mesh topology is modified, e.g. by using adaptive mesh refinement (AMR). Therefore, `markBadQualityCells` should be included unconditionally whenever the mesh topology changes (`mesh.changing()` instead of `mesh.moving()`). Currently, using AMR can either lead to limiting the pressure gradient in the wrong cells (because the cell IDs did change) or to a segmentation fault if the mesh is unrefined and thus the total number of cells reduces.